### PR TITLE
chore(release): 1.0.0-beta.11

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@nextcloud/cypress",
-  "version": "1.0.0-beta.10",
+  "version": "1.0.0-beta.11",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@nextcloud/cypress",
-      "version": "1.0.0-beta.10",
+      "version": "1.0.0-beta.11",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "dockerode": "^4.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nextcloud/cypress",
-  "version": "1.0.0-beta.10",
+  "version": "1.0.0-beta.11",
   "description": "Nextcloud cypress commands, utils and selectors library",
   "main": "dist/index.cjs",
   "module": "dist/index.js",


### PR DESCRIPTION
## What's Changed

### Features

* feat: Export runCommand and runOccCommand by @artonge in https://github.com/nextcloud-libraries/nextcloud-cypress/pull/688

### Fixes

* fix: Target the whole data directory in save/restore state command by @artonge in https://github.com/nextcloud-libraries/nextcloud-cypress/pull/692

**Full Changelog**: https://github.com/nextcloud-libraries/nextcloud-cypress/compare/v1.0.0-beta.10...v1.0.0-beta.11