### PR TITLE
cleanup(deps): drop cypress peer dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -42,9 +42,6 @@
       "engines": {
         "node": "^20.0.0",
         "npm": "^10.0.0"
-      },
-      "peerDependencies": {
-        "cypress": "^13.9.0"
       }
     },
     "node_modules/@achrinza/node-ipc": {

--- a/package.json
+++ b/package.json
@@ -66,9 +66,6 @@
     "npm": "^10.0.0"
   },
   "homepage": "https://github.com/nextcloud/nextcloud-cypress",
-  "peerDependencies": {
-    "cypress": "^13.9.0"
-  },
   "dependencies": {
     "dockerode": "^4.0.2",
     "fast-xml-parser": "^4.3.6",

--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -10,7 +10,7 @@ import packageJSON from './package.json' assert { type: 'json' }
 
 const external = [
 	...Object.keys(packageJSON.dependencies),
-	...Object.keys(packageJSON.peerDependencies)
+	...Object.keys(packageJSON.peerDependencies ?? {})
 ]
 
 const config = (input, output) => ({


### PR DESCRIPTION
See #601.

This package is also used in playwright tests.
Remove the peer dependency to avaoid automatic installation of cypress.

I also considered making it an optional dependency. But then it would still be installed by default.