### PR TITLE
fix: Auto expose port on macOS to make it accessible on the host

### DIFF
--- a/lib/docker.ts
+++ b/lib/docker.ts
@@ -170,6 +170,9 @@ export async function startNextcloud(branch = 'master', mountApp: boolean|string
 			}],
 		}
 
+		// On macOS we need to expose the port since the docker container is running within a VM
+		const autoExposePort = process.platform === 'darwin'
+
 		const container = await docker.createContainer({
 			Image: SERVER_IMAGE,
 			name: getContainerName(),
@@ -177,6 +180,7 @@ export async function startNextcloud(branch = 'master', mountApp: boolean|string
 			HostConfig: {
 				Binds: mounts.length > 0 ? mounts : undefined,
 				PortBindings,
+				PublishAllPorts: autoExposePort,
 				// Mount data directory in RAM for faster IO
 				Mounts: [{
 					Target: '/var/www/html/data',
@@ -326,6 +330,13 @@ export const stopNextcloud = async function() {
 export const getContainerIP = async function(
 	container = getContainer()
 ): Promise<string> {
+	const containerInspect = await container.inspect()
+	const hostPort = containerInspect.NetworkSettings.Ports['80/tcp']?.[0]?.HostPort
+
+	if (hostPort) {
+		return `localhost:${hostPort}`
+	}
+
 	let ip = ''
 	let tries = 0
 	while (ip === '' && tries < 10) {


### PR DESCRIPTION
Thanks to @SystemKeeper we can now run the docker containers on ARM. Now it turned out that accessing the container IP does not work on macOS since the docker host is running inside of a VM there. We need to expose the port to the actual host system. Might also be needed for Windows with WSL but I don't have a setup to test this.

This PR adds auto exposing the port as this gives the flexibility to take any random port and uses any exposed port if present when using getContainerIP.