### PR TITLE
chore(release): 1.0.0-beta.13 (2025-02-04)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@nextcloud/cypress",
-  "version": "1.0.0-beta.12",
+  "version": "1.0.0-beta.13",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@nextcloud/cypress",
-      "version": "1.0.0-beta.12",
+      "version": "1.0.0-beta.13",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "dockerode": "^4.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nextcloud/cypress",
-  "version": "1.0.0-beta.12",
+  "version": "1.0.0-beta.13",
   "description": "Nextcloud cypress commands, utils and selectors library",
   "main": "dist/index.cjs",
   "module": "dist/index.js",


### PR DESCRIPTION
* feat(docker): addUser command ([3a541ee](https://github.com/nextcloud/nextcloud-cypress/commit/3a541ee))
* feat(docker): allow string command in runExec and runOcc ([39073b3](https://github.com/nextcloud/nextcloud-cypress/commit/39073b3))
* feat(docker): commands with optional args as options ([f9c4a98](https://github.com/nextcloud/nextcloud-cypress/commit/f9c4a98))
* feat(docker): export runExec, add runOcc, getSystemConfig, setSystemConfig ([c91ff54](https://github.com/nextcloud/nextcloud-cypress/commit/c91ff54))
* fix: Auto expose port on macOS to make it accessible on the host ([48f0e31](https://github.com/nextcloud/nextcloud-cypress/commit/48f0e31))
* fix(docker): try to use existing image if pulling fails ([614a152](https://github.com/nextcloud/nextcloud-cypress/commit/614a152))
* test(cy): cy.runCommand and cy.runOccCommand ([fed018f](https://github.com/nextcloud/nextcloud-cypress/commit/fed018f))

**Full Changelog**: https://github.com/nextcloud-libraries/nextcloud-cypress/compare/v1.0.0-beta.12...v1.0.0-beta.13