### PR TITLE
fix: Do not depend on the 'path' package for basename

### DIFF
--- a/lib/commands/docker.ts
+++ b/lib/commands/docker.ts
@@ -3,7 +3,10 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
-import { basename } from 'path'
+function basename(path: string): string {
+	return path.split('/').pop() as string
+}
+
 
 function getContainerName(): Cypress.Chainable<string> {
 	return cy.exec('pwd').then(({ stdout }) => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@nextcloud/cypress",
-  "version": "1.0.0-beta.13",
+  "version": "1.0.0-beta.14",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@nextcloud/cypress",
-      "version": "1.0.0-beta.13",
+      "version": "1.0.0-beta.14",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "dockerode": "^4.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nextcloud/cypress",
-  "version": "1.0.0-beta.13",
+  "version": "1.0.0-beta.14",
   "description": "Nextcloud cypress commands, utils and selectors library",
   "main": "dist/index.cjs",
   "module": "dist/index.js",


### PR DESCRIPTION
This is causing issues with ESM: "process is not defined".

Include package version bump